### PR TITLE
fix: GH-17 - Initialize 'always on top' at startup

### DIFF
--- a/electron/src/main.js
+++ b/electron/src/main.js
@@ -3,7 +3,6 @@ const { app, BrowserWindow } = require('electron');
 const { 
   loadSettings, 
   registerSettingsHandlers, 
-  settingsEmitter, 
   alwaysOnTopInit 
 } = require('./settings.js');
 const { registerKeyboardShortcuts } = require('./shortcuts.js');

--- a/electron/src/main.js
+++ b/electron/src/main.js
@@ -1,6 +1,11 @@
 /* global  MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY, MAIN_WINDOW_WEBPACK_ENTRY */
 const { app, BrowserWindow } = require('electron');
-const { loadSettings, registerSettingsHandlers, settingsEmitter } = require('./settings.js');
+const { 
+  loadSettings, 
+  registerSettingsHandlers, 
+  settingsEmitter, 
+  alwaysOnTopInit 
+} = require('./settings.js');
 const { registerKeyboardShortcuts } = require('./shortcuts.js');
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
@@ -39,12 +44,7 @@ app
   .then(loadSettings)
   .then(registerSettingsHandlers)
   .then(createWindow)
-  .then((mainWindow) => {
-    settingsEmitter.on('change', (settings) => {
-      mainWindow.setAlwaysOnTop(settings.alwaysOnTop);
-    });
-    return mainWindow;
-  })
+  .then(alwaysOnTopInit)
   .then(registerKeyboardShortcuts);
 
 // Quit when all windows are closed, except on macOS. There, it's common

--- a/electron/src/settings.js
+++ b/electron/src/settings.js
@@ -37,7 +37,7 @@ async function loadSettings() {
   try {
     const settingsJson = await fs.readFile(settingsPath, { encoding: 'utf8' });
     loadedSettings = JSON.parse(settingsJson);
-  } catch (err) {
+  } catch {
     console.warn("Could not load settings, using defaults");
     resetDefaultSettings();
     return;


### PR DESCRIPTION
This PR resolves GH-17 where the 'always on top' feature was not deactivating when expected. It was found that while the app would change the AOT setting when it was toggled in the settings menu, it would not initialize it at startup to the saved settings value. This meant that on start up the app always enabled AOT, even when it was disabled in settings.

This PR also refactors the settings load function for improved readability.