### PR TITLE
[fix][GH-11] Fix reset key defaults shows old setting on click

### DIFF
--- a/web/src/components/Settings/Menu/KeyItem.js
+++ b/web/src/components/Settings/Menu/KeyItem.js
@@ -33,8 +33,9 @@ export default function KeyItem({ name, value, onChange }) {
     if (newShortcut.size !== 0) {
       onChange(setToShortcut(newShortcut));
       newShortcut.clear();
+      setDisplay(value);
     }
-  }, [setReading, onChange]);
+  }, [setReading, onChange, setDisplay]);
 
   return <div className='row justify-content-start'>
            <h5 className='col'>


### PR DESCRIPTION
This PR resolves GH-11, a bug where after resetting the default settings, clicking on a keyboard shortcut settings bar would cause it to show the old setting before the reset.

The issue was that the keyboard shortcut input was not resetting the state of the entered keyboard shortcut while 'reading'. When the input would regain focus it would display this outdated 'reading' display state. This PR resets the 'reading' display state when the input loses focus.