### PR TITLE
Fix keyboard shortcuts getting stuck

### DIFF
--- a/components/src/Settings/Items/KeyItem.jsx
+++ b/components/src/Settings/Items/KeyItem.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useState, useCallback, useEffect } from 'react';
 
-import { setToShortcut } from '../../util/shortcuts';
+import { setIsOnlyModifiers, setToShortcut } from '../../util/shortcuts';
 
 import InputDisplay from '../../Input/InputDisplay';
 import { Item } from './Item';
@@ -9,13 +9,14 @@ import { Item } from './Item';
 const newShortcut = new Set();
 
 function keyIsInvalid(key) {
+  console.log(key);
   switch (key) {
     case 'Escape':
     case 'Enter':
     case ' ':
     case 'Backspace':
       return true;
-    default: 
+    default:
       return false;
   }
 }
@@ -26,7 +27,7 @@ export function KeyItem({ name, value, onChange, children }) {
 
   useEffect(() => {
     const handler = (event) => {
-      if (keyIsInvalid(event.key)) {
+      if (keyIsInvalid(event.code)) {
         event.target.blur();
         return;
       }
@@ -36,7 +37,7 @@ export function KeyItem({ name, value, onChange, children }) {
         return;
       }
 
-      newShortcut.add(event.key);
+      newShortcut.add(event.code);
       setDisplay(setToShortcut(newShortcut));
     };
 
@@ -54,11 +55,12 @@ export function KeyItem({ name, value, onChange, children }) {
   const handleBlur = useCallback(() => {
     setReading(false);
 
-    if (newShortcut.size !== 0) {
+    if (newShortcut.size !== 0 && !setIsOnlyModifiers(newShortcut)) {
       onChange(setToShortcut(newShortcut));
-      newShortcut.clear();
-      setDisplay(value);
     }
+
+    newShortcut.clear();
+    setDisplay(value);
   }, [setReading, onChange, setDisplay, value]);
 
   return (

--- a/components/src/util/shortcuts.js
+++ b/components/src/util/shortcuts.js
@@ -4,21 +4,186 @@ import { setEquals } from '.';
 
 const isMacOS = window.navigator.userAgent.indexOf("Mac") === 0;
 
-const electron_to_web_code_map = {
-  CommandOrControl: isMacOS ? "Meta" : "Control",
-  CmdOrCtrl: isMacOS ? "Meta" : "Control",
-  Command: "Meta",
-  Cmd: "Meta",
-  Super: "Meta",
-  Option: "Alt",
-  Esc: "Escape",
-  Plus: "+",
-  Space: " ",
-  Return: "Enter",
-  Up: "ArrowUp",
-  Down: "ArrowDown",
-  Left: "ArrowLeft",
-  Right: "ArrowRight",
+const web_code_to_electron_key_map = {
+  Escape: "Esc",
+  Digit1: "1",
+  Digit2: "2",
+  Digit3: "3",
+  Digit4: "4",
+  Digit5: "5",
+  Digit6: "6",
+  Digit7: "7",
+  Digit8: "8",
+  Digit9: "9",
+  Digit0: "0",
+  Minus: "-",
+  Equal: "=",
+  Backspace: "Backspace",
+  Tab: "Tab",
+  KeyQ: "Q",
+  KeyW: "W",
+  KeyE: "E",
+  KeyR: "R",
+  KeyT: "T",
+  KeyY: "Y",
+  KeyU: "U",
+  KeyI: "I",
+  KeyO: "O",
+  KeyP: "P",
+  BracketLeft: "[",
+  BracketRight: "]",
+  Enter: "Enter",
+  ControlLeft: "Ctrl",
+  KeyA: "A",
+  KeyS: "S",
+  KeyD: "D",
+  KeyF: "F",
+  KeyG: "G",
+  KeyH: "H",
+  KeyJ: "J",
+  KeyK: "K",
+  KeyL: "L",
+  Semicolon: ";",
+  Quote: "'",
+  Backquote: "`",
+  ShiftLeft: "Shift",
+  Backslash: "\\",
+  KeyZ: "Z",
+  KeyX: "X",
+  KeyC: "C",
+  KeyV: "V",
+  KeyB: "B",
+  KeyN: "N",
+  KeyM: "M",
+  Comma: ",",
+  Period: ".",
+  Slash: "/",
+  ShiftRight: "Shift",
+  NumpadMultiply: "nummult",
+  AltLeft: "Alt",
+  Space: "Space",
+  CapsLock: "Capslock",
+  F1: "F1",
+  F2: "F2",
+  F3: "F3",
+  F4: "F4",
+  F5: "F5",
+  F6: "F6",
+  F7: "F7",
+  F8: "F8",
+  F9: "F9",
+  F10: "F10",
+  Pause: "MediaPlayPause",
+  ScrollLock: "Scrollock",
+  Numpad7: "num7",
+  Numpad8: "num8",
+  Numpad9: "num9",
+  NumpadSubtract: "numsub",
+  Numpad4: "num4",
+  Numpad5: "num5",
+  Numpad6: "num6",
+  NumpadAdd: "numadd",
+  Numpad1: "num1",
+  Numpad2: "num2",
+  Numpad3: "num3",
+  Numpad0: "num0",
+  NumpadDecimal: "numdec",
+  PrintScreen: "PrintScreen",
+  IntlBackslash: "",
+  F11: "F11",
+  F12: "F12",
+  NumpadEqual: "=",
+  F13: "F13",
+  F14: "F14",
+  F15: "F15",
+  F16: "F16",
+  F17: "F17",
+  F18: "F18",
+  F19: "F19",
+  F20: "F20",
+  F21: "F21",
+  F22: "F22",
+  F23: "F23",
+  F24: "F24",
+  KanaMode: "",
+  Lang2: "",
+  Lang1: "",
+  IntlRo: "",
+  Convert: "",
+  NonConvert: "",
+  IntlYen: "",
+  NumpadComma: ",",
+  Undo: "",
+  Paste: "",
+  MediaTrackPrevious: "MediaPreviousTrack",
+  Cut: "",
+  Copy: "",
+  MediaTrackNext: "MediaNextTrack",
+  NumpadEnter: "Enter",
+  ControlRight: "Ctrl",
+  AudioVolumeMute: "VolumeMute",
+  LaunchApp2: "",
+  MediaPlayPause: "MediaPlayPause",
+  MediaStop: "MediaStop",
+  Eject: "",
+  AudioVolumeDown: "VolumeDown",
+  AudioVolumeUp: "VolumeUp",
+  BrowserHome: "",
+  NumpadDivide: "numdiv",
+  PrintScreen: "PrintScreen",
+  AltRight: "Alt",
+  Help: "",
+  NumLock: "Numlock",
+  Pause: "MediaPlayPause",
+  Home: "Home",
+  ArrowUp: "Up",
+  PageUp: "PageUp",
+  ArrowLeft: "Left",
+  ArrowRight: "Right",
+  End: "End",
+  ArrowDown: "Down",
+  PageDown: "PageDown",
+  Insert: "Insert",
+  Delete: "Delete",
+  MetaLeft: "Cmd",
+  MetaRight: "Cmd",
+  ContextMenu: "",
+  Power: "",
+  Sleep: "",
+  WakeUp: "",
+  BrowserSearch: "",
+  BrowserFavorites: "",
+  BrowserRefresh: "",
+  BrowserStop: "",
+  BrowserForward: "",
+  BrowserBack: "",
+  LaunchApp1: "",
+  LaunchMail: "",
+  MediaSelect: "",
+}
+let electron_to_web_code_map = {};
+for (const [key, value] of Object.entries(web_code_to_electron_key_map)) {
+  if (electron_to_web_code_map[value] === undefined) {
+    electron_to_web_code_map[value] = key;
+  }
+}
+
+/* DEPRECATED - But don't get rid of it because it was a pain to make
+const  electron_to_web_key_map = {
+  CommandOrControl: isMacOS  ? "Meta" : "Control",
+  CmdOrCtrl: isMacOS  ? "Meta" : "Control",
+  Command: "Meta", 
+  Cmd: "Meta", 
+  Super: "Meta", 
+  Option: "Alt", 
+  Esc: "Escape", 
+  Plus: "+", 
+  Space: " ", 
+  Return: "Enter", 
+  Up: "ArrowUp", 
+  Down: "ArrowDown", 
+  Left: "ArrowLeft", 
+  Right: "ArrowRight", 
   "numdec": "Decimal",
   "numadd": "Add",
   "numsub": "Subtract",
@@ -36,9 +201,10 @@ const electron_to_web_code_map = {
   num9: "9",
 }
 let web_key_to_electron_map = {};
-for (const [key, value] of Object.entries(electron_to_web_code_map)) {
+for (const [key, value] of Object.entries(electron_to_web_key_map)) {
   web_key_to_electron_map[value] = key;
 }
+*/
 
 function parseShortcut(shortcutString) {
   const keyStrs = shortcutString.split("+");
@@ -56,27 +222,57 @@ function parseShortcut(shortcutString) {
   return keys;
 }
 
+export function setIsOnlyModifiers(keySet) {
+  for (const key of keySet) {
+    switch (web_code_to_electron_key_map[key]) {
+      case "Cmd":
+      case "Ctrl":
+      case "Alt":
+      case "Shift":
+        continue;
+      default:
+        return false;
+    }
+  }
+  return true;
+}
+
 export function setToShortcut(keySet) {
   let result = '';
 
   for (const key of keySet) {
-    if (web_key_to_electron_map[key] !== undefined) {
-      result += '+';
-      result += web_key_to_electron_map[key];
+    if (web_code_to_electron_key_map[key] === undefined) {
       continue;
     }
 
-    if (key.length === 1) {
-      result += '+';
-      result += key.toUpperCase();
+    if (web_code_to_electron_key_map[key] === '') {
       continue;
     }
 
-    result += '+';
-    result += key;
+    if (result !== '') {
+      result += '+';
+    }
+
+    result += web_code_to_electron_key_map[key];
+
+    // if (web_key_to_electron_map[key] !== undefined) {
+    //   result += '+';
+    //   result += web_key_to_electron_map[key];
+    //   continue;
+    // }
+
+    // if (key.length === 1) {
+    //   result += '+';
+    //   result += key.toUpperCase();
+    //   continue;
+    // }
+
+    // result += '+';
+    // result += key;
   }
 
-  return result.slice(1);
+  return result;
+  // return result.slice(1);
 }
 
 export function useShortcut(callback, shortcut, electronTarget) {

--- a/components/src/util/shortcuts.js
+++ b/components/src/util/shortcuts.js
@@ -250,25 +250,9 @@ export function setToShortcut(keySet) {
     }
 
     result += web_code_to_electron_key_map[key];
-
-    // if (web_key_to_electron_map[key] !== undefined) {
-    //   result += '+';
-    //   result += web_key_to_electron_map[key];
-    //   continue;
-    // }
-
-    // if (key.length === 1) {
-    //   result += '+';
-    //   result += key.toUpperCase();
-    //   continue;
-    // }
-
-    // result += '+';
-    // result += key;
   }
 
   return result;
-  // return result.slice(1);
 }
 
 export function useShortcut(callback, shortcut, electronTarget) {

--- a/components/src/util/shortcuts.js
+++ b/components/src/util/shortcuts.js
@@ -2,8 +2,6 @@ import { useEffect, useCallback } from 'react';
 
 import { setEquals } from '.';
 
-const isMacOS = window.navigator.userAgent.indexOf("Mac") === 0;
-
 const web_code_to_electron_key_map = {
   Escape: "Esc",
   Digit1: "1",
@@ -73,7 +71,6 @@ const web_code_to_electron_key_map = {
   F8: "F8",
   F9: "F9",
   F10: "F10",
-  Pause: "MediaPlayPause",
   ScrollLock: "Scrollock",
   Numpad7: "num7",
   Numpad8: "num8",
@@ -130,7 +127,6 @@ const web_code_to_electron_key_map = {
   AudioVolumeUp: "VolumeUp",
   BrowserHome: "",
   NumpadDivide: "numdiv",
-  PrintScreen: "PrintScreen",
   AltRight: "Alt",
   Help: "",
   NumLock: "Numlock",

--- a/electron/src/shortcuts.cjs
+++ b/electron/src/shortcuts.cjs
@@ -3,21 +3,44 @@ const {
 } = require('electron');
 const {
   settingsEmitter,
-  getSettings
+  getSettings,
+  changeSettings
 } = require('./settings.cjs');
+const { defaultSettings } = require("../../components/src/settings/schema");
 
 function registerCountShortcuts(mainWindow) {
-  const shortcuts = getSettings().keyboardShortcuts;
+  let settings = getSettings();
+  const shortcuts = settings.keyboardShortcuts;
 
-  globalShortcut.register(shortcuts.incrementCount, () => {
+  let status = globalShortcut.register(shortcuts.incrementCount, () => {
     mainWindow.webContents.send('increment-counter');
   });
-  globalShortcut.register(shortcuts.decrementCount, () => {
+  if (!status) {
+    console.log("Invalid increment count shortcut", shortcuts.incrementCount);
+    settings.keyboardShortcuts.incrementCount = defaultSettings.keyboardShortcuts.incrementCount; 
+    changeSettings(settings);
+    return;
+  }
+
+  status = globalShortcut.register(shortcuts.decrementCount, () => {
     mainWindow.webContents.send('decrement-counter');
   });
-  globalShortcut.register(shortcuts.resetCount, () => {
+  if (!status) {
+    console.log("Invalid decrement count shortcut", shortcuts.decrementCount);
+    settings.keyboardShortcuts.decrementCount = defaultSettings.keyboardShortcuts.decrementCount; 
+    changeSettings(settings);
+    return;
+  }
+
+  status = globalShortcut.register(shortcuts.resetCount, () => {
     mainWindow.webContents.send('reset-counter');
   });
+  if (!status) {
+    console.log("Invalid reset count shortcut", shortcuts.resetCount);
+    settings.keyboardShortcuts.resetCount = defaultSettings.keyboardShortcuts.resetCount; 
+    changeSettings(settings);
+    return;
+  }
 }
 
 async function registerKeyboardShortcuts(mainWindow) {


### PR DESCRIPTION
This PR resolves GH-49, a bug where the keyboard shortcut settings menu entry sometimes gets stuck when entering an invalid shortcut.

The resolution was to switch to using the key event `code` property instead of `key`. This PR also adds some error handling on the Electron side for improper keyboard shortcuts.