### PR TITLE
Add linear / track watching mode

### DIFF
--- a/components/src/Settings/Menu/CounterSettings.jsx
+++ b/components/src/Settings/Menu/CounterSettings.jsx
@@ -16,7 +16,7 @@ export function CounterSettings() {
                             onChange={ setMode }
                             options={[ 
                             { name: 'Manual', value: 'manual' },
-                            { name: 'Pro Tools File Watcher', value: 'fileWatcher' },
+                            { name: 'Pro Tools File Watcher', value: 'ptFileWatcher' },
                             ]} /> 
         </>
     )    

--- a/components/src/Settings/Menu/FileWatcherSettings.jsx
+++ b/components/src/Settings/Menu/FileWatcherSettings.jsx
@@ -6,17 +6,17 @@ import { TextItem, PathItem, DropdownItem, IntegerItem } from '../Items/index';
 export function FileWatcherSettings() {
     const [counterMode] = useSetting('counterMode');
     const [fileWatcherMode, setFileWatcherMode] = useSetting('ptFileWatcherMode', 'mode');
-    const [playlistMode, setPlaylistMode] = useSetting('ptFileWatcherMode', 'playlistMode', 'mode');
+    const [fileWatcherSubMode, setFileWatcherSubMode] = useSetting('ptFileWatcherMode', 'subMode');
     const [trackName, setTrackName] = useSetting('ptFileWatcherMode', 'trackName');
     const [audioFilesPath, setAudioFilesPath] = useSetting('ptFileWatcherMode', 'audioFilesPath');
     const [offset, setOffset] = useSetting('ptFileWatcherMode', 'offset');
 
-    const handleSetPlaylistMode = useCallback((mode) => {
-        if (playlistMode === 'allFiles') {
+    const handleSetSubMode = useCallback((mode) => {
+        if (mode === 'all') {
             setTrackName('');
         }
-        setPlaylistMode(mode);
-    }, [playlistMode, setPlaylistMode, setTrackName]);
+        setFileWatcherSubMode(mode);
+    }, [fileWatcherSubMode, setFileWatcherSubMode, setTrackName]);
 
     if (window.settings === undefined) {
         return undefined;
@@ -28,23 +28,34 @@ export function FileWatcherSettings() {
 
     const trackModeSettings = 
         <>
-            <TextItem name='Track name'
-                        value={ trackName }
-                        onChange={ setTrackName }> 
-            </TextItem>
+            <DropdownItem name='Track to watch'
+                          value={ fileWatcherSubMode }
+                          onChange={ handleSetSubMode }
+                          options={[
+                              { name: 'All tracks', value: 'all' },
+                              { name: 'Specific track', value: 'specific' },
+                          ]}/>
+            {
+                fileWatcherSubMode === 'specific' ?
+                <TextItem name='Track name'
+                            value={ trackName }
+                            onChange={ setTrackName }> 
+                </TextItem>
+                : undefined
+            }
         </>;
 
     const playlistModeSettings = 
         <>
             <DropdownItem name='Playlist to watch'
-                          value={ playlistMode }
-                          onChange={ handleSetPlaylistMode }
+                          value={ fileWatcherSubMode }
+                          onChange={ handleSetSubMode }
                           options={[
-                              { name: 'All playlists', value: 'allPlaylists' },
-                              { name: 'Specific playlist', value: 'specificPlaylist' },
+                              { name: 'All playlists', value: 'all' },
+                              { name: 'Specific playlist', value: 'specific' },
                           ]}/>
             {
-                playlistMode === 'specificPlaylist' ?
+                fileWatcherSubMode === 'specific' ?
                 <TextItem name='Playlist name'
                           value={ trackName }
                           onChange={ setTrackName }> 

--- a/components/src/Settings/Menu/FileWatcherSettings.jsx
+++ b/components/src/Settings/Menu/FileWatcherSettings.jsx
@@ -5,46 +5,59 @@ import { TextItem, PathItem, DropdownItem, IntegerItem } from '../Items/index';
 
 export function FileWatcherSettings() {
     const [counterMode] = useSetting('counterMode');
-    const [fileWatcherMode, setFileWatcherMode] = useSetting('fileWatcherMode', 'mode');
-    const [trackName, setTrackName] = useSetting('fileWatcherMode', 'trackName');
-    const [audioFilesPath, setAudioFilesPath] = useSetting('fileWatcherMode', 'audioFilesPath');
-    const [offset, setOffset] = useSetting('fileWatcherMode', 'offset');
+    const [fileWatcherMode, setFileWatcherMode] = useSetting('ptFileWatcherMode', 'mode');
+    const [playlistMode, setPlaylistMode] = useSetting('ptFileWatcherMode', 'playlistMode', 'mode');
+    const [trackName, setTrackName] = useSetting('ptFileWatcherMode', 'trackName');
+    const [audioFilesPath, setAudioFilesPath] = useSetting('ptFileWatcherMode', 'audioFilesPath');
+    const [offset, setOffset] = useSetting('ptFileWatcherMode', 'offset');
 
-    const handleSetMode = useCallback((mode) => {
-        if (mode === 'allFiles') {
+    const handleSetPlaylistMode = useCallback((mode) => {
+        if (playlistMode === 'allFiles') {
             setTrackName('');
         }
-        setFileWatcherMode(mode);
-    }, [setFileWatcherMode, setTrackName]);
+        setPlaylistMode(mode);
+    }, [playlistMode, setPlaylistMode, setTrackName]);
 
     if (window.settings === undefined) {
         return undefined;
     }
 
-    if (counterMode !== 'fileWatcher') {
+    if (counterMode !== 'ptFileWatcher') {
         return undefined;
     }
+
+    const trackModeSettings = 
+        <>
+            <TextItem name='Track name'
+                        value={ trackName }
+                        onChange={ setTrackName }> 
+            </TextItem>
+        </>;
+
+    const playlistModeSettings = 
+        <>
+            <DropdownItem name='Playlist to watch'
+                          value={ playlistMode }
+                          onChange={ handleSetPlaylistMode }
+                          options={[
+                              { name: 'All playlists', value: 'allPlaylists' },
+                              { name: 'Specific playlist', value: 'specificPlaylist' },
+                          ]}/>
+            {
+                playlistMode === 'specificPlaylist' ?
+                <TextItem name='Playlist name'
+                          value={ trackName }
+                          onChange={ setTrackName }> 
+                </TextItem>
+                : undefined
+            }
+        </>;
 
     return (
         <div>
             <h4 className='row border-bottom mt-3'>
                 Pro Tools File Watcher
             </h4>
-            <DropdownItem name='Files to watch'
-                          value={ fileWatcherMode }
-                          onChange={ handleSetMode }
-                          options={[
-                            { name: 'All files', value: 'allFiles' },
-                            { name: 'Specific Track', value: 'specificTrack' },
-                          ]}/>
-            {
-                fileWatcherMode === 'specificTrack' ?
-                <TextItem name='Track name'
-                            value={ trackName }
-                            onChange={ setTrackName }> 
-                </TextItem>
-                : undefined
-            }
             <PathItem name='Audio files path'
                         value={ audioFilesPath }
                         onChange={ setAudioFilesPath }/>
@@ -53,6 +66,18 @@ export function FileWatcherSettings() {
                          onChange={ setOffset }>
                 Add or subtract from the automatic take value.
             </IntegerItem>
+            <DropdownItem name='What to watch'
+                          value={ fileWatcherMode }
+                          onChange={ setFileWatcherMode }
+                          options={[
+                              { name: 'Track', value: 'track' },
+                              { name: 'Playlist(s)', value: 'playlist' },
+                          ]}/>
+            {
+                fileWatcherMode === 'playlist' ?
+                playlistModeSettings 
+                : trackModeSettings
+            }
         </div>
     );
 }

--- a/components/src/Settings/schema.js
+++ b/components/src/Settings/schema.js
@@ -6,7 +6,16 @@ export const defaultSettings = {
     resetCount: "Alt+Shift+0"
   },
   alwaysOnTop: false,
-  counterMode: 'manual',
+  counterMode: 'manual', /* manual, ptFileWatcher */
+  ptFileWatcherMode: {
+    mode: 'track', /* track, playlist */
+    offset: 0,
+    trackName: '',
+    audioFilesPath: '',
+    playlistMode: {
+      mode: 'allPlaylists' /* allPlaylists, specificPlaylist */
+    }
+  },
   fileWatcherMode: {
     mode: 'allFiles',
     audioFilesPath: '',

--- a/components/src/Settings/schema.js
+++ b/components/src/Settings/schema.js
@@ -9,18 +9,10 @@ export const defaultSettings = {
   counterMode: 'manual', /* manual, ptFileWatcher */
   ptFileWatcherMode: {
     mode: 'track', /* track, playlist */
+    subMode: 'all', /* all, specific */
     offset: 0,
     trackName: '',
-    audioFilesPath: '',
-    playlistMode: {
-      mode: 'allPlaylists' /* allPlaylists, specificPlaylist */
-    }
-  },
-  fileWatcherMode: {
-    mode: 'allFiles',
-    audioFilesPath: '',
-    trackName: '',
-    offset: 0,
+    audioFilesPath: ''
   }
 };
 

--- a/components/src/__snapshots__/TakeCounter.test.js.snap
+++ b/components/src/__snapshots__/TakeCounter.test.js.snap
@@ -97,7 +97,7 @@ exports[`Matches snapshot 1`] = `
                     Manual
                   </option>
                   <option
-                    value="fileWatcher"
+                    value="ptFileWatcher"
                   >
                     Pro Tools File Watcher
                   </option>

--- a/electron/src/file_watcher/file_watcher.mjs
+++ b/electron/src/file_watcher/file_watcher.mjs
@@ -160,10 +160,6 @@ export class PlaylistWatcher extends EventTarget {
     changeAudioFilesPath(directory) {
         this.audioFilePath = directory;
 
-        if (!this.isWatching) {
-            return Promise.resolve();
-        }
-
         return this.stopWatching()
             .then(() => {
                 return this.watchTrackName(this.trackName);

--- a/electron/src/file_watcher/index.mjs
+++ b/electron/src/file_watcher/index.mjs
@@ -1,5 +1,5 @@
 import { settingsEmitter } from "../settings.cjs";
-import { FileWatcher, PlaylistWatcher, TrackWatcher } from "./file_watcher.mjs";
+import { PlaylistWatcher, TrackWatcher } from "./file_watcher.mjs";
 
 let audioFilesPath;
 let trackName;

--- a/electron/src/file_watcher/index.mjs
+++ b/electron/src/file_watcher/index.mjs
@@ -32,51 +32,54 @@ function handleNewSettings(settings) {
 }
 
 async function handleFileWatcherMode(fileWatcherSettings) {
-    if (!mode || !watcher || mode != fileWatcherSettings.mode) {
-        if (watcher) {
+    if (mode === undefined || mode != fileWatcherSettings.mode) {
+        if (watcher !== undefined) {
             await watcher.stopWatching();
         }
 
         mode = fileWatcherSettings.mode;
-        watcher = getWatcher(fileWatcherSettings.mode);
-
-        if (audioFilesPath) {
-            await watcher.changeAudioFilesPath(audioFilesPath);
-        }
-
-        if (trackName !== undefined) {
-            await watcher.watchTrackName(trackName);
-        }
-
-        if (offset) {
-            watcher.setOffset(offset);
-        }
+        watcher = await getWatcher(mode);
     }
 
-    if (!audioFilesPath || audioFilesPath != fileWatcherSettings.audioFilesPath) {
+    if (audioFilesPath === undefined || audioFilesPath != fileWatcherSettings.audioFilesPath) {
         audioFilesPath = fileWatcherSettings.audioFilesPath; 
         await watcher.changeAudioFilesPath(audioFilesPath);
     } 
 
-    if (!trackName || trackName != fileWatcherSettings.trackName) {
+    if (trackName === undefined || trackName != fileWatcherSettings.trackName) {
         trackName = fileWatcherSettings.trackName;
         await watcher.watchTrackName(trackName);
     }
 
-    if (!offset || offset != fileWatcherSettings.offset) {
+    if (offset === undefined || offset != fileWatcherSettings.offset) {
         offset = fileWatcherSettings.offset;
         watcher.setOffset(offset);
     }
 } 
 
-function getWatcher(fileWatcherMode) {
+async function getWatcher(fileWatcherMode) {
     let watcher;
+
     if (fileWatcherMode === 'track') {
         watcher = new TrackWatcher('');
     } else {
         watcher = new PlaylistWatcher('');
     }
+
     watcher.addEventListener('takeUpdate', handleTakeChange);
+
+    if (audioFilesPath !== undefined) {
+        await watcher.changeAudioFilesPath(audioFilesPath);
+    }
+
+    if (trackName !== undefined) {
+        await watcher.watchTrackName(trackName);
+    }
+
+    if (offset !== undefined) {
+        watcher.setOffset(offset);
+    }
+
     return watcher;
 }
 

--- a/electron/src/file_watcher/index.mjs
+++ b/electron/src/file_watcher/index.mjs
@@ -20,14 +20,14 @@ export async function fileWatcherInit(mainWindow) {
 }
 
 function handleNewSettings(settings) {
-    if (settings.counterMode != 'fileWatcher') {
+    if (settings.counterMode != 'ptFileWatcher') {
         if (watcher) {
             watcher.stopWatching();
         }
         return;
     }
 
-    handleFileWatcherMode(settings.fileWatcherMode);
+    handleFileWatcherMode(settings.ptFileWatcherMode);
 }
 
 async function handleFileWatcherMode(fileWatcherSettings) {

--- a/electron/src/file_watcher/playlist_watcher.test.mjs
+++ b/electron/src/file_watcher/playlist_watcher.test.mjs
@@ -7,7 +7,7 @@ import outputFiles from 'output-files';
 import endent_formats from 'endent';
 const endent = endent_formats.default;
 
-import { FileWatcher } from './file_watcher';
+import { PlaylistWatcher } from './file_watcher';
 
 const test = process.env.CI ? jestTest.skip : jestTest;
 
@@ -32,7 +32,7 @@ test('start and stop watcher', () => withLocalTmpDir(async () => {
             'whatever.txt': `Some file to create the Audio Files folder`
         }
     });
-    const watcher = new FileWatcher('Audio Files');
+    const watcher = new PlaylistWatcher('Audio Files');
 
     await watcher.watchTrackName('Audio 1');
 
@@ -49,7 +49,7 @@ test('get current take', () => withLocalTmpDir(async () => {
             'whatever.txt': `Some file to create the Audio Files folder`
         }
     });
-    const watcher = new FileWatcher('Audio Files');
+    const watcher = new PlaylistWatcher('Audio Files');
 
     expect(watcher.currentTake)
         .toEqual(0);
@@ -86,7 +86,7 @@ test('change track to watch', () => withLocalTmpDir(async () => {
             'whatever.txt': `Some file to create the Audio Files folder`
         }
     });
-    const watcher = new FileWatcher('Audio Files');
+    const watcher = new PlaylistWatcher('Audio Files');
 
     await watcher.watchTrackName('Audio 1');
     await watcher.nextUpdate();
@@ -131,7 +131,7 @@ test('emit event when take changes', () => withLocalTmpDir(async () => {
             'whatever.txt': `Some file to create the Audio Files folder`
         }
     });
-    const watcher = new FileWatcher('Audio Files');
+    const watcher = new PlaylistWatcher('Audio Files');
     await watcher.watchTrackName('Audio 1');
     await watcher.nextUpdate();
 
@@ -180,7 +180,7 @@ test('stop a watcher that hasnt started', () => withLocalTmpDir(async () => {
             'whatever.txt': `Some file to create the Audio Files folder`
         }
     });
-    const watcher = new FileWatcher('Audio Files');
+    const watcher = new PlaylistWatcher('Audio Files');
     await watcher.stopWatching();
 }));
 
@@ -193,7 +193,7 @@ test('change path to Audio Files', () => withLocalTmpDir(async () => {
             'whatever.txt': `Some file to create the Other Files folder`
         }
     });
-    const watcher = new FileWatcher('Audio Files');
+    const watcher = new PlaylistWatcher('Audio Files');
 
     await watcher.watchTrackName('Audio 1');
     await watcher.nextUpdate();
@@ -232,7 +232,7 @@ test('not watching with default settings', () => withLocalTmpDir(async () => {
             'whatever.txt': `Some file to create the Other Files folder`
         }
     });
-    const watcher = new FileWatcher('');
+    const watcher = new PlaylistWatcher('');
     await watcher.watchTrackName('');
 
     await watcher.nextUpdate();
@@ -246,7 +246,7 @@ test('watch all files when blank track name', () => withLocalTmpDir(async () => 
             'whatever.txt': `Some file to create the Audio Files folder`
         }
     });
-    const watcher = new FileWatcher('Audio Files');
+    const watcher = new PlaylistWatcher('Audio Files');
 
     await watcher.watchTrackName('');
     await watcher.nextUpdate();
@@ -290,7 +290,7 @@ test('change offset', () => withLocalTmpDir(async () => {
             'whatever.txt': `Some file to create the Audio Files folder`
         }
     });
-    const watcher = new FileWatcher('Audio Files');
+    const watcher = new PlaylistWatcher('Audio Files');
 
     await watcher.watchTrackName('');
     await watcher.nextUpdate();

--- a/electron/src/file_watcher/track_watcher.test.mjs
+++ b/electron/src/file_watcher/track_watcher.test.mjs
@@ -1,0 +1,59 @@
+import { readFile } from 'node:fs/promises';
+
+import { test as jestTest, expect, jest } from '@jest/globals';
+
+import withLocalTmpDir from 'with-local-tmp-dir';
+import outputFiles from 'output-files';
+import endent_formats from 'endent';
+const endent = endent_formats.default;
+
+import { TrackWatcher } from './file_watcher';
+
+const test = process.env.CI ? jestTest.skip : jestTest;
+
+test('get current take', () => withLocalTmpDir(async () => {
+    await outputFiles({
+        'Audio Files': {
+            'whatever.txt': `Some file to create the Audio Files folder`
+        }
+    });
+    const watcher = new TrackWatcher('Audio Files');
+
+    expect(watcher.currentTake)
+        .toEqual(0);
+
+    await watcher.watchTrackName('Audio 1');
+    await watcher.nextUpdate();
+
+    await outputFiles({
+        'Audio Files': {
+            'Audio 1_01.wav': ``
+        }
+    });
+
+    await watcher.nextUpdate();
+    expect(watcher.currentTake)
+        .toEqual(1);
+
+    await outputFiles({
+        'Audio Files': {
+            'Audio 1.01_01.wav': ``
+        }
+    });
+
+    await watcher.nextUpdate();
+    expect(watcher.currentTake)
+        .toEqual(1);
+
+    await outputFiles({
+        'Audio Files': {
+            'Audio 1.01_02.wav': ``
+        }
+    });
+
+    await watcher.nextUpdate();
+    expect(watcher.currentTake)
+        .toEqual(2);
+
+    await watcher.stopWatching();
+}));

--- a/electron/src/file_watcher/track_watcher.test.mjs
+++ b/electron/src/file_watcher/track_watcher.test.mjs
@@ -1,11 +1,7 @@
-import { readFile } from 'node:fs/promises';
-
-import { test as jestTest, expect, jest } from '@jest/globals';
+import { test as jestTest, expect } from '@jest/globals';
 
 import withLocalTmpDir from 'with-local-tmp-dir';
 import outputFiles from 'output-files';
-import endent_formats from 'endent';
-const endent = endent_formats.default;
 
 import { TrackWatcher } from './file_watcher';
 


### PR DESCRIPTION
This PR adds a new 'track' watching mode to the Pro Tools File Watcher. Now, users can select whether they want to watch tracks or playlists. The new track watcher mode will observe the clip number in either a specific track or all tracks and keep the take at the most recent one.