### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Something is not working correctly
+title: "[BUG]"
+labels: bug
+assignees: kclapper
+
+---
+
+> Don't feel obliged to fill all these in
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Version or Git reference:**
+Which Take Counter release version are you using? Or, if you're working on Take Counter, which commit / branch are you using?
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]"
+labels: feature
+assignees: kclapper
+
+---
+
+> Don't feel obliged to fill all of these in
+
+**Describe your feature request**
+A clear and concise description of what you want to happen.
+
+**If your feature request solves a problem in your workflow, please describe your workflow**
+A clear and concise description of your work flow. 
+
+**If your feature request solves a problem in your workflow, are there other ways to solve it?**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This PR adds new issue templates to the repo. The main reason for this is to automatically label them and assign myself.