### PR TITLE
GH-62 - Make mode indicator fancier

### DIFF
--- a/components/src/Counter/ModeIndicator.jsx
+++ b/components/src/Counter/ModeIndicator.jsx
@@ -1,0 +1,28 @@
+import React, { useCallback, useState } from 'react';
+
+import { useSetting } from '../Settings';
+
+export default function ModeIndicator() {
+    const [counterMode] = useSetting('counterMode');
+    const [fileWatcherMode] = useSetting('ptFileWatcherMode', 'mode');
+
+    let modeIndicator;
+
+    switch (counterMode) {
+        case "ptFileWatcher":
+            modeIndicator = "Pro Tools File Watcher Mode";
+            modeIndicator += ` (${fileWatcherMode})`;
+            break;
+        case "manual":
+        default:
+            return <></>;
+    }
+
+    return (
+        <div>
+            <p className='text-info fw-bold'>
+                {modeIndicator}
+            </p>
+        </div>
+    )
+}

--- a/components/src/Counter/ModeIndicator.jsx
+++ b/components/src/Counter/ModeIndicator.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React from 'react';
 
 import { useSetting } from '../Settings';
 

--- a/components/src/Counter/index.jsx
+++ b/components/src/Counter/index.jsx
@@ -24,8 +24,6 @@ function Counter() {
   const [takeTextPrefix] = useSetting('takeDisplaySettings', 'takeTextPrefix');
   const [showTakePrefix] = useSetting('takeDisplaySettings', 'showTakePrefix');
   const [showTakeButtons] = useSetting('takeDisplaySettings', 'showTakeButtons');
-  const [fileWatcherMode] = useSetting('ptFileWatcherMode', 'mode');
-  const [counterMode] = useSetting('counterMode');
 
   const incrementCount = useCallback(() => {
     setTake(take + 1);

--- a/components/src/Counter/index.jsx
+++ b/components/src/Counter/index.jsx
@@ -7,6 +7,7 @@ import { useSetting } from '../Settings';
 
 import Button from '../Button';
 import TakeInputDisplay from './TakeInputDisplay';
+import ModeIndicator from './ModeIndicator';
 
 function Counter() {
   const [take, setRawTake] = useSetting('currentTake');
@@ -80,11 +81,7 @@ function Counter() {
               {showTakeButtons && buttons}
             </div>
             <div style={{ flexGrow: 1 }}/>
-            <div>
-              <p className='text-info fw-bold'>
-                {counterMode} {counterMode == "ptFileWatcher" && fileWatcherMode} mode
-              </p>
-            </div>
+            <ModeIndicator />
          </div>
 }
 

--- a/components/src/Settings/schema.js
+++ b/components/src/Settings/schema.js
@@ -9,7 +9,7 @@ export const defaultSettings = {
   showDetailsBox: true,
   counterMode: 'manual', /* manual, ptFileWatcher */
   ptFileWatcherMode: {
-    mode: 'track', /* track, playlist */
+    mode: 'clip', /* clip, playlist */
     subMode: 'all', /* all, specific */
     offset: 0,
     trackName: '',

--- a/components/src/__snapshots__/TakeCounter.test.js.snap
+++ b/components/src/__snapshots__/TakeCounter.test.js.snap
@@ -357,13 +357,6 @@ exports[`Matches snapshot 1`] = `
       <div
         style="flex-grow: 1;"
       />
-      <div>
-        <p
-          class="text-info fw-bold"
-        >
-          manual  mode
-        </p>
-      </div>
     </div>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
This PR adds a new `ModeIndicator` component to make the mode indicator on the main screen slightly fancier. Now, formatted text can be used in place of the settings value. This PR also makes it so the mode indicator is not shown when in manual mode.

This PR closes GH-62.