### PR TITLE
GH-56 - Add option to change offset with shortcuts

### DIFF
--- a/components/src/Button/index.jsx
+++ b/components/src/Button/index.jsx
@@ -1,27 +1,35 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useRef, useEffect } from 'react';
 
 import bootstrap from 'bootstrap/dist/js/bootstrap.bundle';
 
 function Button({ onClick, tooltipPlacement, tooltip, className, children}) {
-
   const element = useRef(null);
+  const bootstrapTooltip = useRef(null);
 
   useEffect(() => {
     if (element.current !== null && Boolean(tooltip)) {
-      new bootstrap.Tooltip(element.current, {
+      bootstrapTooltip.current = new bootstrap.Tooltip(element.current, {
         delay: {
-          show: 1000,
+          show: 1500,
           hide: 200
         }
       });
     }
   }, [tooltip, tooltipPlacement, element]);
 
+  const handleClick = useCallback(() => {
+    if (bootstrapTooltip.current === null) {
+      return;
+    }
+    bootstrapTooltip.current.hide();
+    onClick();
+  }, [onClick, bootstrapTooltip]);
+
   return <button ref={ element }
                  className={ className || 'btn btn-primary m-1' }
                  type='button'
-                 onClick={ onClick }
+                 onClick={ handleClick }
                  data-bs-toggle="tooltip"
                  data-bs-placement={ tooltipPlacement || "top" }
                  data-bs-title={ tooltip }>

--- a/components/src/Button/index.test.js
+++ b/components/src/Button/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expect, it } from '@jest/globals';
 
@@ -37,5 +37,8 @@ it('Renders tooltip', async () => {
 
   fireEvent.mouseOver(getByText('Click Me!'));
 
-  expect(await findByText('test')).toBeVisible();
+  await waitFor(async () => {
+    expect(await findByText('test')).toBeVisible();
+  }, { timeout: 2000 });
+
 });

--- a/components/src/Counter/ModeIndicator.jsx
+++ b/components/src/Counter/ModeIndicator.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 
 import { useSetting } from '../Settings';
+import { defaultSettings } from '../Settings/schema';
 
 export default function ModeIndicator() {
     const [counterMode] = useSetting('counterMode');
     const [fileWatcherMode] = useSetting('ptFileWatcherMode', 'mode');
+    const [offset] = useSetting('ptFileWatcherMode', 'offset');
+    const [showOffset] = useSetting('ptFileWatcherMode', 'showOffset');
 
     let modeIndicator;
 
@@ -18,10 +21,22 @@ export default function ModeIndicator() {
             return <></>;
     }
 
+    const offsetIndicator = 
+        showOffset
+        && offset !== defaultSettings.ptFileWatcherMode.offset 
+        && (
+            <>
+                <br/>
+                Offset: {offset}
+            </>
+        );
+
     return (
         <div>
-            <p className='text-info fw-bold'>
+            <p className='text-info fw-bold text-center'>
+                {offsetIndicator ? undefined : <br/>}
                 {modeIndicator}
+                {offsetIndicator}
             </p>
         </div>
     )

--- a/components/src/Counter/index.jsx
+++ b/components/src/Counter/index.jsx
@@ -4,6 +4,7 @@ import { useEffect, useCallback } from 'react';
 import { getValidatedCount } from '../util';
 import { useShortcut } from '../util/shortcuts';
 import { useSetting } from '../Settings';
+import { defaultSettings } from '../Settings/schema';
 
 import Button from '../Button';
 import TakeInputDisplay from './TakeInputDisplay';
@@ -11,14 +12,24 @@ import ModeIndicator from './ModeIndicator';
 
 function Counter() {
   const [take, setRawTake] = useSetting('currentTake');
+  const [offset, setOffset] = useSetting('ptFileWatcherMode', 'offset');
+  const [offsetShortcuts] = useSetting('ptFileWatcherMode', 'offsetShortcuts');
 
   const setTake = useCallback((newCount) => {
+    if (offsetShortcuts) {
+      let value = Number(newCount);
+      if (Number.isInteger(value)) {
+        setOffset(value);
+      }
+      return;
+    }
+
     const validatedNewCount = getValidatedCount(newCount);
     setRawTake(validatedNewCount);
-  }, [setRawTake]);
+  }, [setRawTake, setOffset, offsetShortcuts]);
 
   if (window.counter !== undefined) {
-    window.counter.handleSetCount(setTake);
+    window.counter.handleSetCount(setRawTake);
   }
 
   const [takeTextPrefix] = useSetting('takeDisplaySettings', 'takeTextPrefix');
@@ -26,13 +37,18 @@ function Counter() {
   const [showTakeButtons] = useSetting('takeDisplaySettings', 'showTakeButtons');
 
   const incrementCount = useCallback(() => {
-    setTake(take + 1);
-  }, [take, setTake]);
+    let value = offsetShortcuts ? offset : take;
+    setTake(value + 1);
+  }, [take, setTake, offset, offsetShortcuts]);
+
   const decrementCount = useCallback(() => {
-    setTake(take - 1);
-  }, [take, setTake])
+    let value = offsetShortcuts ? offset : take;
+    setTake(value - 1);
+  }, [take, setTake, offset, offsetShortcuts])
+
   const resetTake = useCallback(() => {
-    setTake(1);
+    let value = offsetShortcuts ? defaultSettings.ptFileWatcherMode.offset : 1;
+    setTake(value);
   }, [setTake]);
 
   useEffect(() => {
@@ -52,7 +68,7 @@ function Counter() {
                       -
                     </Button>
                     <Button onClick={resetTake}
-                            tooltip={shortcuts.resetTake}
+                            tooltip={shortcuts.resetCount}
                             tooltipPlacement="bottom">
                       reset
                     </Button>
@@ -64,7 +80,7 @@ function Counter() {
                   </>
 
   return <div className='d-flex flex-column align-items-center justify-content-center' style={{ flexGrow: 1 }}>
-           <div style={{ flexGrow: 0.75 }}/>
+           <div style={{ flexGrow: 1 }}/>
            <div className="d-flex"> 
               {
                 showTakePrefix ?
@@ -76,10 +92,10 @@ function Counter() {
              <TakeInputDisplay take={ take } onInput={ setTake } />
            </div>
            <div className='' style={{ flexGrow: 0 }}>
-              {showTakeButtons && buttons}
-            </div>
-            <div style={{ flexGrow: 1 }}/>
-            <ModeIndicator />
+             {showTakeButtons && buttons}
+           </div>
+           <div style={{ flexGrow: 1 }}/>
+           <ModeIndicator />
          </div>
 }
 

--- a/components/src/Counter/index.jsx
+++ b/components/src/Counter/index.jsx
@@ -15,7 +15,7 @@ function Counter() {
   const [offset, setOffset] = useSetting('ptFileWatcherMode', 'offset');
   const [offsetShortcuts] = useSetting('ptFileWatcherMode', 'offsetShortcuts');
 
-  const setTake = useCallback((newCount) => {
+  const setValue = useCallback((newCount) => {
     if (offsetShortcuts) {
       let value = Number(newCount);
       if (Number.isInteger(value)) {
@@ -38,18 +38,18 @@ function Counter() {
 
   const incrementCount = useCallback(() => {
     let value = offsetShortcuts ? offset : take;
-    setTake(value + 1);
-  }, [take, setTake, offset, offsetShortcuts]);
+    setValue(value + 1);
+  }, [take, setValue, offset, offsetShortcuts]);
 
   const decrementCount = useCallback(() => {
     let value = offsetShortcuts ? offset : take;
-    setTake(value - 1);
-  }, [take, setTake, offset, offsetShortcuts])
+    setValue(value - 1);
+  }, [take, setValue, offset, offsetShortcuts])
 
   const resetTake = useCallback(() => {
     let value = offsetShortcuts ? defaultSettings.ptFileWatcherMode.offset : 1;
-    setTake(value);
-  }, [setTake]);
+    setValue(value);
+  }, [setValue]);
 
   useEffect(() => {
     document.title = "Take " + take;
@@ -89,7 +89,7 @@ function Counter() {
                 </h1>         
                 : undefined
               }
-             <TakeInputDisplay take={ take } onInput={ setTake } />
+             <TakeInputDisplay take={ take } onInput={ setValue } />
            </div>
            <div className='' style={{ flexGrow: 0 }}>
              {showTakeButtons && buttons}

--- a/components/src/Counter/index.jsx
+++ b/components/src/Counter/index.jsx
@@ -12,11 +12,16 @@ import ModeIndicator from './ModeIndicator';
 
 function Counter() {
   const [take, setRawTake] = useSetting('currentTake');
+  const [mode] = useSetting('counterMode');
   const [offset, setOffset] = useSetting('ptFileWatcherMode', 'offset');
   const [offsetShortcuts] = useSetting('ptFileWatcherMode', 'offsetShortcuts');
 
+  const offsetShortcutsEnabled = useCallback(() => {
+    return mode === "ptFileWatcher" && offsetShortcuts;
+  }, [offsetShortcuts, mode]);
+
   const setValue = useCallback((newCount) => {
-    if (offsetShortcuts) {
+    if (offsetShortcutsEnabled()) {
       let value = Number(newCount);
       if (Number.isInteger(value)) {
         setOffset(value);
@@ -26,7 +31,7 @@ function Counter() {
 
     const validatedNewCount = getValidatedCount(newCount);
     setRawTake(validatedNewCount);
-  }, [setRawTake, setOffset, offsetShortcuts]);
+  }, [setRawTake, setOffset, offsetShortcutsEnabled]);
 
   if (window.counter !== undefined) {
     window.counter.handleSetCount(setRawTake);
@@ -37,19 +42,19 @@ function Counter() {
   const [showTakeButtons] = useSetting('takeDisplaySettings', 'showTakeButtons');
 
   const incrementCount = useCallback(() => {
-    let value = offsetShortcuts ? offset : take;
+    let value = offsetShortcutsEnabled() ? offset : take;
     setValue(value + 1);
-  }, [take, setValue, offset, offsetShortcuts]);
+  }, [take, setValue, offset, offsetShortcutsEnabled]);
 
   const decrementCount = useCallback(() => {
-    let value = offsetShortcuts ? offset : take;
+    let value = offsetShortcutsEnabled() ? offset : take;
     setValue(value - 1);
-  }, [take, setValue, offset, offsetShortcuts])
+  }, [take, setValue, offset, offsetShortcutsEnabled])
 
   const resetTake = useCallback(() => {
-    let value = offsetShortcuts ? defaultSettings.ptFileWatcherMode.offset : 1;
+    let value = offsetShortcutsEnabled() ? defaultSettings.ptFileWatcherMode.offset : 1;
     setValue(value);
-  }, [setValue]);
+  }, [setValue, offsetShortcutsEnabled]);
 
   useEffect(() => {
     document.title = "Take " + take;
@@ -80,7 +85,7 @@ function Counter() {
                   </>
 
   return <div className='d-flex flex-column align-items-center justify-content-center' style={{ flexGrow: 1 }}>
-           <div style={{ flexGrow: 1 }}/>
+           <div style={{ flexGrow: mode === "manual" ? 0.75 : 1 }}/>
            <div className="d-flex"> 
               {
                 showTakePrefix ?

--- a/components/src/Settings/Items/IntegerItem.jsx
+++ b/components/src/Settings/Items/IntegerItem.jsx
@@ -5,7 +5,7 @@ import { TextItem } from './TextItem';
 
 export function IntegerItem({ name, value, onChange, children }) {
   const handleChange = useCallback((input) => {
-    if (input.trim() === '') {
+    if (typeof(input) === "string" && input.trim() === '') {
       return;
     }
 

--- a/components/src/Settings/Menu/FileWatcherSettings.jsx
+++ b/components/src/Settings/Menu/FileWatcherSettings.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 
 import { useSetting } from '..';
-import { TextItem, PathItem, DropdownItem, IntegerItem } from '../Items/index';
+import { TextItem, PathItem, DropdownItem, IntegerItem, BooleanItem } from '../Items/index';
 
 export function FileWatcherSettings() {
     const [counterMode] = useSetting('counterMode');
@@ -10,6 +10,7 @@ export function FileWatcherSettings() {
     const [trackName, setTrackName] = useSetting('ptFileWatcherMode', 'trackName');
     const [audioFilesPath, setAudioFilesPath] = useSetting('ptFileWatcherMode', 'audioFilesPath');
     const [offset, setOffset] = useSetting('ptFileWatcherMode', 'offset');
+    const [offsetShortcuts, setOffsetShortcuts] = useSetting('ptFileWatcherMode', 'offsetShortcuts');
 
     const handleSetSubMode = useCallback((mode) => {
         if (mode === 'all') {
@@ -89,6 +90,11 @@ export function FileWatcherSettings() {
                          onChange={ setOffset }>
                 Offset adjusts the automatic take value up or down.
             </IntegerItem>
+            <BooleanItem name='Offset Shortcuts'
+                         value={ offsetShortcuts }
+                         onChange={ setOffsetShortcuts }>
+                Counter shortcuts change offset instead of count.
+            </BooleanItem>
         </div>
     );
 }

--- a/components/src/Settings/Menu/FileWatcherSettings.jsx
+++ b/components/src/Settings/Menu/FileWatcherSettings.jsx
@@ -94,7 +94,7 @@ export function FileWatcherSettings() {
             <BooleanItem name='Offset Shortcuts'
                          value={ offsetShortcuts }
                          onChange={ setOffsetShortcuts }>
-                Counter shortcuts change offset instead of count.
+                Counter shortcuts change offset instead of take number.
             </BooleanItem>
             <BooleanItem name='Show offset'
                          value={ showOffset }

--- a/components/src/Settings/Menu/FileWatcherSettings.jsx
+++ b/components/src/Settings/Menu/FileWatcherSettings.jsx
@@ -11,6 +11,7 @@ export function FileWatcherSettings() {
     const [audioFilesPath, setAudioFilesPath] = useSetting('ptFileWatcherMode', 'audioFilesPath');
     const [offset, setOffset] = useSetting('ptFileWatcherMode', 'offset');
     const [offsetShortcuts, setOffsetShortcuts] = useSetting('ptFileWatcherMode', 'offsetShortcuts');
+    const [showOffset, setShowOffset] = useSetting('ptFileWatcherMode', 'showOffset');
 
     const handleSetSubMode = useCallback((mode) => {
         if (mode === 'all') {
@@ -94,6 +95,11 @@ export function FileWatcherSettings() {
                          value={ offsetShortcuts }
                          onChange={ setOffsetShortcuts }>
                 Counter shortcuts change offset instead of count.
+            </BooleanItem>
+            <BooleanItem name='Show offset'
+                         value={ showOffset }
+                         onChange={ setShowOffset }>
+                Shows the current offset on the main screen
             </BooleanItem>
         </div>
     );

--- a/components/src/Settings/schema.js
+++ b/components/src/Settings/schema.js
@@ -13,6 +13,7 @@ export const defaultSettings = {
     subMode: 'all', /* all, specific */
     offset: 0,
     offsetShortcuts: false,
+    showOffset: true,
     trackName: '',
     audioFilesPath: ''
   },

--- a/components/src/Settings/schema.js
+++ b/components/src/Settings/schema.js
@@ -12,6 +12,7 @@ export const defaultSettings = {
     mode: 'clip', /* clip, playlist */
     subMode: 'all', /* all, specific */
     offset: 0,
+    offsetShortcuts: false,
     trackName: '',
     audioFilesPath: ''
   },

--- a/components/src/__snapshots__/TakeCounter.test.js.snap
+++ b/components/src/__snapshots__/TakeCounter.test.js.snap
@@ -334,7 +334,7 @@ exports[`Matches snapshot 1`] = `
       style="flex-grow: 1;"
     >
       <div
-        style="flex-grow: 0.75;"
+        style="flex-grow: 1;"
       />
       <div
         class="d-flex"
@@ -366,6 +366,7 @@ exports[`Matches snapshot 1`] = `
         <button
           class="btn btn-primary m-1"
           data-bs-placement="bottom"
+          data-bs-title="Alt+Shift+0"
           data-bs-toggle="tooltip"
           type="button"
         >

--- a/components/src/__snapshots__/TakeCounter.test.js.snap
+++ b/components/src/__snapshots__/TakeCounter.test.js.snap
@@ -334,7 +334,7 @@ exports[`Matches snapshot 1`] = `
       style="flex-grow: 1;"
     >
       <div
-        style="flex-grow: 1;"
+        style="flex-grow: 0.75;"
       />
       <div
         class="d-flex"

--- a/electron/src/file_watcher/file_watcher.mjs
+++ b/electron/src/file_watcher/file_watcher.mjs
@@ -47,12 +47,12 @@ export class PlaylistWatcher extends EventTarget {
 
     get currentTake() {
         if (!this.lastAudioFile) {
-            return 0;
+            return this.offset < 0 ? 1 : this.offset;
         }
 
         const lastTake = this.parseTake(this.lastAudioFile);
         if (lastTake === false) {
-            return 0;
+            return this.offset < 0 ? 1 : this.offset;
         }
 
         return lastTake;

--- a/electron/src/file_watcher/index.mjs
+++ b/electron/src/file_watcher/index.mjs
@@ -54,6 +54,7 @@ async function handleFileWatcherMode(fileWatcherSettings) {
     if (offset === undefined || offset != fileWatcherSettings.offset) {
         offset = fileWatcherSettings.offset;
         watcher.setOffset(offset);
+        notifyNewTake(watcher.currentTake);
     }
 } 
 

--- a/electron/src/file_watcher/playlist_watcher.test.mjs
+++ b/electron/src/file_watcher/playlist_watcher.test.mjs
@@ -163,18 +163,6 @@ test('change path to Audio Files', () => withLocalTmpDir(async () => {
 
     await outputFiles({
         'Audio Files': {
-            'Audio 1_01.wav': ``
-        }
-    });
-    await watcher.nextUpdate();
-
-    expect(watcher.currentTake)
-        .toEqual(1);
-
-    await watcher.changeAudioFilesPath('Other Files');
-
-    await outputFiles({
-        'Other Files': {
             'Audio 1.01_01.wav': ``
         }
     });
@@ -182,6 +170,18 @@ test('change path to Audio Files', () => withLocalTmpDir(async () => {
 
     expect(watcher.currentTake)
         .toEqual(2);
+
+    await watcher.changeAudioFilesPath('Other Files');
+
+    await outputFiles({
+        'Other Files': {
+            'Audio 1.02_01.wav': ``
+        }
+    });
+    await watcher.nextUpdate();
+
+    expect(watcher.currentTake)
+        .toEqual(3);
 
     await watcher.stopWatching();
 }));
@@ -307,7 +307,7 @@ test('watch subfolders', () => withLocalTmpDir(async () => {
     const watcher = new PlaylistWatcher('parent folder');
 
     expect(watcher.currentTake)
-        .toEqual(0);
+        .toEqual(1);
 
     await watcher.watchTrackName('Audio 1');
     await watcher.nextUpdate();
@@ -318,18 +318,6 @@ test('watch subfolders', () => withLocalTmpDir(async () => {
     await outputFiles({
         'parent folder': {
             'Audio Files': {
-                'Audio 1_01.wav': ``
-            }
-        }
-    });
-
-    await watcher.nextUpdate();
-    expect(watcher.currentTake)
-        .toEqual(1);
-
-    await outputFiles({
-        'parent folder': {
-            'Other Audio Files': {
                 'Audio 1.01_01.wav': ``
             }
         }
@@ -338,6 +326,18 @@ test('watch subfolders', () => withLocalTmpDir(async () => {
     await watcher.nextUpdate();
     expect(watcher.currentTake)
         .toEqual(2);
+
+    await outputFiles({
+        'parent folder': {
+            'Other Audio Files': {
+                'Audio 1.02_01.wav': ``
+            }
+        }
+    });
+
+    await watcher.nextUpdate();
+    expect(watcher.currentTake)
+        .toEqual(3);
 
     await watcher.stopWatching();
 }));
@@ -355,23 +355,23 @@ test('handle .wav and .aif files', () => withLocalTmpDir(async () => {
 
     await outputFiles({
         'Audio Files': {
-            'Audio 1_01.wav': ``
-        }
-    });
-    await watcher.nextUpdate();
-
-    expect(watcher.currentTake)
-        .toEqual(1);
-
-    await outputFiles({
-        'Audio Files': {
-            'Audio 1.01_01.aif': ``
+            'Audio 1.01_01.wav': ``
         }
     });
     await watcher.nextUpdate();
 
     expect(watcher.currentTake)
         .toEqual(2);
+
+    await outputFiles({
+        'Audio Files': {
+            'Audio 1.02_01.aif': ``
+        }
+    });
+    await watcher.nextUpdate();
+
+    expect(watcher.currentTake)
+        .toEqual(3);
 
     await watcher.stopWatching();
 }));


### PR DESCRIPTION
This PR adds a new option that makes the take shortcuts and buttons change the offset when in Pro Tools File Watcher mode. It also adds a new option to display the offset on the main page.

Now, when the offset changes, the take will be updated on the main page as well.

This PR also updates the button tooltips so the tooltip disappears when the button is clicked.